### PR TITLE
Updated based upon my gem checklist

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+require: rubocop-rspec
+
+Metrics/MethodLength:
+  Max: 20
+
+RSpec/EmptyExampleGroup:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.3
@@ -10,8 +9,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.0
-      os: osx
     - rvm: 2.4
       os: osx
 os:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Rspec::Tabular
 
 [![Gem Version](https://badge.fury.io/rb/rspec-tabular.svg)](http://badge.fury.io/rb/rspec-tabular)
-[![Dependency Status](https://gemnasium.com/sugarcrm/rspec-tabular.svg)](https://gemnasium.com/sugarcrm/rspec-tabular)
 [![Build Status](https://travis-ci.org/sugarcrm/rspec-tabular.svg?branch=master)](https://travis-ci.org/sugarcrm/rspec-tabular)
 [![Code Climate](https://codeclimate.com/github/sugarcrm/rspec-tabular/badges/gpa.svg)](https://codeclimate.com/github/sugarcrm/rspec-tabular)
 [![Test Coverage](https://codeclimate.com/github/sugarcrm/rspec-tabular/badges/coverage.svg)](https://codeclimate.com/github/sugarcrm/rspec-tabular/coverage)

--- a/Rakefile
+++ b/Rakefile
@@ -2,18 +2,38 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
+require 'bundler/audit/task'
 require 'pathname'
+require 'license_finder'
+require 'English'
 
-RSpec::Core::RakeTask.new(:spec)
-
-RuboCop::RakeTask.new(:rubocop) do |task|
-  rake_application_pathname = Pathname(Rake.application.original_dir)
-  rubocop_report_pathname = rake_application_pathname.join('tmp', 'rubocop.txt')
-  rubocop_report_pathname.dirname.mkpath
-  task.options =
-    %w[--display-cop-names --extra-details --display-style-guide] +
-    %w[--format progress] +
-    %w[--format simple --out].push(rubocop_report_pathname.to_s)
+RSpec::Core::RakeTask.new(:spec) do |task|
+  task.rspec_opts = '--warnings'
 end
 
-task default: :spec
+RuboCop::RakeTask.new(:rubocop) do |task|
+  rubocop_report_pathname =
+    Pathname(Rake.application.original_dir).join('tmp', 'rubocop.txt')
+  rubocop_report_pathname.dirname.mkpath
+  task.requires << 'rubocop-rspec'
+  task.options =
+    %w[
+      --display-cop-names
+      --extra-details
+      --display-style-guide
+      --fail-level error
+      --format progress
+      --format simple --out
+    ].push(rubocop_report_pathname.to_s)
+end
+
+Bundler::Audit::Task.new
+
+desc 'Check dependency licenses'
+task :license_finder do
+  puts `license_finder --quiet --format text`
+
+  abort('LicenseFinder failed') unless $CHILD_STATUS.success?
+end
+
+task default: %i[spec rubocop bundle:audit license_finder]

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,25 @@
+---
+- - :ignore_group
+  - development
+  - :who: Andrew Sullivan Cant <mail@andrewsullivancant.ca>
+    :why: 
+    :versions: []
+    :when: 2018-06-13 15:20:17.351348000 Z
+- - :whitelist
+  - Apache 2.0
+  - :who: Andrew Sullivan Cant <mail@andrewsullivancant.ca>
+    :why: SugarCRM's primary approved open source license
+    :versions: []
+    :when: 2018-06-18 19:28:33.314061000 Z
+- - :whitelist
+  - MIT
+  - :who: Andrew Sullivan Cant <mail@andrewsullivancant.ca>
+    :why: SugarCRM's secondary approved open source license
+    :versions: []
+    :when: 2018-06-13 15:18:36.240771000 Z
+- - :whitelist
+  - BSD
+  - :who: Andrew Sullivan Cant <mail@andrewsullivancant.ca>
+    :why: SugarCRM's secondary approved open source license
+    :versions: []
+    :when: 2018-06-18 19:29:15.003697000 Z

--- a/rspec-tabular.gemspec
+++ b/rspec-tabular.gemspec
@@ -14,14 +14,26 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/sugarcrm/rspec-tabular'
   spec.license       = 'Apache-2.0'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.1.0'
+
   spec.add_runtime_dependency     'rspec-core', '>= 2.99.0'
+
   spec.add_development_dependency 'bundler',    '~> 1.7'
   spec.add_development_dependency 'rake',       '~> 10.0'
   spec.add_development_dependency 'rspec',      '~> 2.99.0'
-  spec.add_development_dependency 'rubocop',    '>= 0.30.0'
+
+  # Dependencies whose APIs we do not really depend upon, and can be upgraded
+  # without limiting.
+  spec.add_development_dependency 'bundler-audit'
+  spec.add_development_dependency 'license_finder'
+  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'bundler/setup'
+
+# Setup code coverage
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
* remove gemnasium badge, because the service has been EOLed
* set the required Ruby version to >= 2.1.0, and update TravisCI
* add rubocop-rspec
* add bundler-audit
* add license_finder, including the default approvals