### PR TITLE
Add support for it context values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,11 +4,18 @@ Metrics/LineLength:
   Max: 100
 
 Metrics/MethodLength:
-  Max: 20
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
 
 RSpec/EmptyExampleGroup:
   Enabled: false
 
+RSpec/ImplicitSubject:
+  Enabled: false
+
 Metrics/BlockLength:
+  Max: 100
   Exclude:
     - spec/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
   - jruby
 matrix:

--- a/lib/rspec/tabular.rb
+++ b/lib/rspec/tabular.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require 'rspec/tabular/version'
+require 'rspec/tabular/wrapped'
 
-module Rspec
+module RSpec
   # rubocop:disable all
 
   # This module will allow examples to be specified in a more clean tabular
@@ -69,6 +70,17 @@ module Rspec
   #     side_effects_with 'value4', 'value5', 'value6'
   #   end
   #
+  # Values that need an it/before scope can be wrapped using the helper function
+  # `with_context`. An optional 2nd parameter will provide a value to write out
+  # to the reporter
+  #
+  #   describe 'a thing with item compairsons' do
+  #     subject { subject.thing(input1) }
+  #
+  #     inputs  :input1
+  #     it_with with_context(proc { instance_double(ThingyModel) }), 'foobar'
+  #     it_with with_context(proc { double }, 'double'),             'foobar'
+  #
   # Inputs can also be specified as block arguments. I am not sure if this is
   # really useful, it might be deprecated in the future.
   #
@@ -82,90 +94,107 @@ module Rspec
 
   # rubocop:enable all
   module Tabular
-    def inputs(*args)
-      metadata[:inputs] ||= args
-    end
-
-    def it_with(*input_values, &block)
-      if block.nil? && (metadata[:inputs].size == input_values.size - 1)
-        expected_value = input_values.pop
-        block = proc { is_expected.to eq(expected_value) }
+    module ExampleGroup
+      def inputs(*args)
+        metadata[:inputs] ||= args
       end
 
-      context("with #{Hash[metadata[:inputs].zip input_values]}") do
-        metadata[:inputs].each_index do |i|
-          key = metadata[:inputs][i]
-          let(key) { input_values[i] }
+      def it_with(*input_values, &block)
+        if block.nil? && (metadata[:inputs].size == input_values.size - 1)
+          expected_value = input_values.pop
+          block = proc { is_expected.to eq(expected_value) }
         end
 
-        example(nil, { input_values: input_values }, &block)
+        context("with #{Hash[metadata[:inputs].zip input_values]}") do
+          metadata[:inputs].each_index do |i|
+            key = metadata[:inputs][i]
+            value = input_values[i]
+            let(key) { _unwrap(value) }
+          end
+
+          example(nil, { input_values: input_values }, &block)
+        end
       end
-    end
 
-    alias specify_with it_with
+      alias specify_with it_with
 
-    # Example with an implicit subject execution
-    def side_effects_with(*args)
-      it_with(*args) do
-        begin
+      # Example with an implicit subject execution
+      def side_effects_with(*args)
+        it_with(*args) do
+          begin
           subject
-        rescue Exception # rubocop:disable Lint/HandleExceptions, Lint/RescueException
-        end
-      end
-    end
-
-    def raise_error_with(*args)
-      raise_error_args = args
-      it_with_args     = raise_error_args.slice!(0, metadata[:inputs].size)
-
-      it_with(*it_with_args) do
-        expect { subject }.to raise_error(*raise_error_args)
-      end
-    end
-
-    def its_with(attribute, *input_values, &block)
-      if block.nil? && (metadata[:inputs].size == input_values.size - 1)
-        expected_value = input_values.pop
-        block = proc { should eq(expected_value) }
-      end
-
-      describe("#{attribute} with #{input_values.join(', ')}") do
-        if attribute.is_a?(Array)
-          let(:__its_subject) { subject[*attribute] }
-        else
-          let(:__its_subject) do
-            attribute_chain = attribute.to_s.split('.')
-            attribute_chain.inject(subject) do |inner_subject, attr|
-              inner_subject.send(attr)
-            end
+          rescue Exception # rubocop:disable Lint/SuppressedException, Lint/RescueException
           end
         end
-
-        def should(matcher = nil, message = nil) # rubocop:disable Lint/NestedMethodDefinition
-          RSpec::Expectations::PositiveExpectationHandler.handle_matcher(
-            __its_subject, matcher, message
-          )
-        end
-
-        def should_not(matcher = nil, message = nil) # rubocop:disable Lint/NestedMethodDefinition
-          RSpec::Expectations::NegativeExpectationHandler.handle_matcher(
-            __its_subject, matcher, message
-          )
-        end
-
-        metadata[:inputs].each_index do |i|
-          key = metadata[:inputs][i]
-          let(key) { input_values[i] }
-        end
-
-        example(nil, { input_values: input_values }, &block)
       end
+
+      def raise_error_with(*args)
+        raise_error_args = args
+        it_with_args     = raise_error_args.slice!(0, metadata[:inputs].size)
+
+        it_with(*it_with_args) do
+          expect { subject }.to raise_error(*raise_error_args)
+        end
+      end
+
+      def its_with(attribute, *input_values, &block)
+        if block.nil? && (metadata[:inputs].size == input_values.size - 1)
+          expected_value = input_values.pop
+          block = proc { should eq(expected_value) }
+        end
+
+        describe("#{attribute} with #{input_values.join(', ')}") do
+          if attribute.is_a?(Array)
+            let(:__its_subject) { subject[*attribute] }
+          else
+            let(:__its_subject) do
+              attribute_chain = attribute.to_s.split('.')
+              attribute_chain.inject(subject) do |inner_subject, attr|
+                inner_subject.send(attr)
+              end
+            end
+          end
+
+          def should(matcher = nil, message = nil) # rubocop:disable Lint/NestedMethodDefinition
+            RSpec::Expectations::PositiveExpectationHandler.handle_matcher(
+              __its_subject, matcher, message
+            )
+          end
+
+          def should_not(matcher = nil, message = nil) # rubocop:disable Lint/NestedMethodDefinition
+            RSpec::Expectations::NegativeExpectationHandler.handle_matcher(
+              __its_subject, matcher, message
+            )
+          end
+
+          metadata[:inputs].each_index do |i|
+            key = metadata[:inputs][i]
+            value = input_values[i]
+            let(key) { _unwrap(value) }
+          end
+
+          example(nil, { input_values: input_values }, &block)
+        end
+      end
+
+      def with_context(proc, pretty_val = nil)
+        RSpec::Tabular::Wrapped.new(proc, pretty_val)
+      end
+
+      # TODO: it_behaves_like_with(example_name, inputs)
     end
 
-    # TODO: it_behaves_like_with(example_name, inputs)
+    module Example
+      def _unwrap(value)
+        return value unless value.is_a?(RSpec::Tabular::Wrapped)
+
+        instance_eval(&value.proc)
+      end
+    end
   end
 end
 
 RSpec.configure do |config|
-  config.extend(Rspec::Tabular)
+  config.extend(RSpec::Tabular::ExampleGroup)
+  config.include(RSpec::Tabular::Example)
 end

--- a/lib/rspec/tabular.rb
+++ b/lib/rspec/tabular.rb
@@ -94,6 +94,7 @@ module RSpec
 
   # rubocop:enable all
   module Tabular
+    # Example group methods e.g. inside describe/context block
     module ExampleGroup
       def inputs(*args)
         metadata[:inputs] ||= args
@@ -121,10 +122,8 @@ module RSpec
       # Example with an implicit subject execution
       def side_effects_with(*args)
         it_with(*args) do
-          begin
           subject
-          rescue Exception # rubocop:disable Lint/SuppressedException, Lint/RescueException
-          end
+        rescue Exception # rubocop:disable Lint/SuppressedException, Lint/RescueException
         end
       end
 
@@ -184,6 +183,7 @@ module RSpec
       # TODO: it_behaves_like_with(example_name, inputs)
     end
 
+    # example level methods: e.g. inside before/it
     module Example
       def _unwrap(value)
         return value unless value.is_a?(RSpec::Tabular::Wrapped)

--- a/lib/rspec/tabular/version.rb
+++ b/lib/rspec/tabular/version.rb
@@ -2,6 +2,6 @@
 
 module Rspec
   module Tabular
-    VERSION = '0.2.0'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/rspec/tabular/wrapped.rb
+++ b/lib/rspec/tabular/wrapped.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Tabular
+    # This class is a wrapper around a proc that will indicate
+    # to tabular that the provided proc should be run against
+    # a spec's context such that variables defined with let and
+    # helper methods like instance_double are available.
+    #
+    # This class should not be called directly. Instead use the
+    # helper function `with_context`
+    class Wrapped
+      def initialize(proc, pretty_val = nil)
+        @proc       = proc
+        @pretty_val = pretty_val
+      end
+
+      attr_reader :proc
+
+      def to_s
+        @pretty_val || 'wrapped_value'
+      end
+
+      alias inspect to_s
+    end
+  end
+end

--- a/rspec-tabular.gemspec
+++ b/rspec-tabular.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_runtime_dependency     'rspec-core', '>= 2.99.0'
 
   spec.add_development_dependency 'bundler',    '~> 1.7'
-  spec.add_development_dependency 'rake',       '~> 10.0'
-  spec.add_development_dependency 'rspec',      '~> 2.99.0'
+  spec.add_development_dependency 'rake',       '~> 12.0'
+  spec.add_development_dependency 'rspec',      '~> 3.5'
 
   # Dependencies whose APIs we do not really depend upon, and can be upgraded
   # without limiting.

--- a/spec/rspec/tabular_spec.rb
+++ b/spec/rspec/tabular_spec.rb
@@ -106,4 +106,12 @@ describe Rspec::Tabular do
     its_with :method1, :value1, :value2, :result1
     its_with :method2, :value1, :value2, :result2
   end
+
+  context 'with wrapped value' do
+    subject { test_class.method(input1, input2) }
+
+    inputs  :input1,                        :input2
+    it_with with_context(proc { :value1 }), :value2,                        :result1
+    it_with :value3,                        with_context(proc { :value4 }), :result2
+  end
 end


### PR DESCRIPTION
* update to a new version of rake and rspec
* properly name the RSpec root level module
* separate example group level methods and example level methods
* add `with_context` method to provide example level methods to a value
* add _unwrap helper method to unwrap values